### PR TITLE
[Hotfix] News components medium screen layout improvement

### DIFF
--- a/src/components/MonthlyStories/NewsCard.js
+++ b/src/components/MonthlyStories/NewsCard.js
@@ -17,15 +17,13 @@ import arrow from '../../assets/arrowBlueRight.png';
 
 const styles = theme => ({
   root: {
-    marginTop: '1.875rem'
+    marginTop: '1.875rem',
+    backgroundColor: '#fff'
   },
   card: {
     width: '100%',
     borderRadius: 0,
-    boxShadow: 'none',
-    [theme.breakpoints.up('md')]: {
-      width: '24.375rem'
-    }
+    boxShadow: 'none'
   },
   cardMedia: {
     width: '100%',
@@ -37,6 +35,9 @@ const styles = theme => ({
   cardContent: {
     padding: '2.03125rem 2.54375rem 1.75rem 1.84375rem',
     [theme.breakpoints.up('md')]: {
+      padding: '1.625rem 2.0625rem 1.9375rem' // .75 of lg
+    },
+    [theme.breakpoints.up('lg')]: {
       padding: '1.625rem 2.75rem 1.9375rem'
     }
   },

--- a/src/components/MonthlyStories/Stories.js
+++ b/src/components/MonthlyStories/Stories.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import classNames from 'classnames';
-
 import { withStyles } from '@material-ui/core';
 
 import NewsCard from './NewsCard';
@@ -11,7 +9,10 @@ const styles = theme => ({
   root: {
     width: '100%',
     alignItems: 'center',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    [theme.breakpoints.up('md')]: {
+      marginTop: '0.9375rem'
+    }
   },
   stories: {
     display: 'flex',
@@ -19,19 +20,16 @@ const styles = theme => ({
     [theme.breakpoints.up('md')]: {
       flexDirection: 'row',
       justifyContent: 'space-evenly',
-      boxShadow: 'none',
-      marginTop: '5.9375rem',
-      marginBottom: '4.0625rem'
+      boxShadow: 'none'
+    },
+    '& div:first-child': {
+      marginLeft: 0
     }
   },
   newsCard: {
     [theme.breakpoints.up('md')]: {
       width: '33.1%',
-      flex: '1 1 0'
-    }
-  },
-  newsCardMargin: {
-    [theme.breakpoints.up('md')]: {
+      flex: '1 1 0',
       marginLeft: '2.109375rem' // .75 of lg
     },
     [theme.breakpoints.up('lg')]: {
@@ -44,18 +42,14 @@ function Stories({ classes, stories }) {
   return (
     <div className={classes.root}>
       <div className={classes.stories}>
-        {stories.map((story, index) => (
+        {stories.map(story => (
           <NewsCard
             key={story.title}
             title={story.title}
             image={story.image}
             date={story.date}
             link={story.link}
-            classes={{
-              root: classNames(classes.newsCard, {
-                [classes.newsCardMargin]: index > 0
-              })
-            }}
+            classes={{ root: classes.newsCard }}
           />
         ))}
       </div>

--- a/src/components/MonthlyStories/Stories.js
+++ b/src/components/MonthlyStories/Stories.js
@@ -18,14 +18,23 @@ const styles = theme => ({
     flexDirection: 'column',
     [theme.breakpoints.up('md')]: {
       flexDirection: 'row',
+      justifyContent: 'space-evenly',
       boxShadow: 'none',
-      marginTop: '95px',
-      marginBottom: '65px',
-      marginRight: '74px'
+      marginTop: '5.9375rem',
+      marginBottom: '4.0625rem'
+    }
+  },
+  newsCard: {
+    [theme.breakpoints.up('md')]: {
+      width: '33.1%',
+      flex: '1 1 0'
     }
   },
   newsCardMargin: {
     [theme.breakpoints.up('md')]: {
+      marginLeft: '2.109375rem' // .75 of lg
+    },
+    [theme.breakpoints.up('lg')]: {
       marginLeft: '2.8125rem'
     }
   }
@@ -35,7 +44,7 @@ function Stories({ classes, stories }) {
   return (
     <div className={classes.root}>
       <div className={classes.stories}>
-        {stories.slice(0, 3).map((story, index) => (
+        {stories.map((story, index) => (
           <NewsCard
             key={story.title}
             title={story.title}
@@ -43,7 +52,9 @@ function Stories({ classes, stories }) {
             date={story.date}
             link={story.link}
             classes={{
-              root: classNames({ [classes.newsCardMargin]: index > 0 })
+              root: classNames(classes.newsCard, {
+                [classes.newsCardMargin]: index > 0
+              })
             }}
           />
         ))}

--- a/src/components/MonthlyStories/StoryOfTheMonth.js
+++ b/src/components/MonthlyStories/StoryOfTheMonth.js
@@ -17,13 +17,12 @@ const styles = theme => ({
     backgroundPosition: 'center',
     marginTop: '2.9375rem',
     [theme.breakpoints.up('md')]: {
-      width: '78.75rem',
       height: '34.21875rem',
       marginTop: '3.25rem'
     }
   },
   background: {
-    width: '90%',
+    width: '88.9%',
     height: '18.40625rem',
     background: 'inherit',
     '-webkit-filter': 'blur(11.3px)',
@@ -32,12 +31,12 @@ const styles = theme => ({
     right: '0',
     bottom: '0',
     [theme.breakpoints.up('md')]: {
-      width: '39.375rem',
-      height: '30rem'
+      width: '50%',
+      height: '87.7%'
     }
   },
   story: {
-    width: '90%',
+    width: '88.9%',
     height: '18.40625rem',
     backgroundColor: 'rgba(255,255,255,0.2)',
     position: 'absolute',
@@ -46,8 +45,11 @@ const styles = theme => ({
     zIndex: '2',
     padding: '1.96875rem 1.875rem',
     [theme.breakpoints.up('md')]: {
-      width: '39.375rem',
-      height: '30rem',
+      width: '50%',
+      height: '87.7%',
+      padding: '4.5625rem 2.8125rem'
+    },
+    [theme.breakpoints.up('lg')]: {
       padding: '4.5625rem 3.75rem'
     }
   },
@@ -69,7 +71,7 @@ const styles = theme => ({
   summary: {
     height: '8.75rem',
     marginTop: '1.875rem',
-    overflowY: 'scroll',
+    overflowY: 'auto',
 
     // Scrollbar: Firefox
     scrollbarColor: '#023256 #fff',

--- a/src/components/MonthlyStories/index.js
+++ b/src/components/MonthlyStories/index.js
@@ -9,8 +9,6 @@ import Stories from './Stories';
 import StoryOfTheMonth from './StoryOfTheMonth';
 import TextArrowLink from '../TextArrowLink';
 
-import Snorkel2 from '../../assets/Snorkel2.png';
-
 const styles = theme => ({
   root: {
     padding: '5.125rem 1.875rem 4.9375rem',
@@ -35,25 +33,6 @@ const styles = theme => ({
       letterSpacing: '0.7px',
       marginBottom: '0.9375rem'
     }
-  },
-  monthStoryContainer: {
-    position: 'relative',
-    width: '1260px',
-    height: '700px',
-    backgroundImage: `url(${Snorkel2})`,
-    backgroundSize: 'cover'
-  },
-  blur: {
-    height: '480px',
-    backgroundImage: `url(${Snorkel2})`,
-    backgroundSize: 'cover',
-    backgroundPosition: 'bottom right',
-    width: '630px',
-    position: 'absolute',
-    filter: 'blur(15px)',
-    zIndex: '1',
-    bottom: '0',
-    right: '0'
   },
   allStories: {
     display: 'flex',

--- a/src/components/MonthlyStories/index.js
+++ b/src/components/MonthlyStories/index.js
@@ -4,18 +4,14 @@ import PropTypes from 'prop-types';
 import Tabletop from 'tabletop';
 import { withStyles, Typography } from '@material-ui/core';
 
+import Section from '../Section';
 import SectionTitle from '../SectionTitle';
 import Stories from './Stories';
 import StoryOfTheMonth from './StoryOfTheMonth';
 import TextArrowLink from '../TextArrowLink';
 
 const styles = theme => ({
-  root: {
-    padding: '5.125rem 1.875rem 4.9375rem',
-    [theme.breakpoints.up('md')]: {
-      padding: '7.875rem 5.5625rem 12.46875rem'
-    }
-  },
+  root: {},
   description: {
     opacity: 0.6,
     fontFamily: 'Montserrat',
@@ -77,7 +73,7 @@ class MonthlyStories extends Component {
     const mainStory = monthStories[0];
     const stories = newsCards.slice(0, 3);
     return (
-      <div className={classes.root}>
+      <Section classes={{ root: classes.root }}>
         <SectionTitle subtitle="Monthly Stories">
           Our Monthly Stories.
         </SectionTitle>
@@ -94,7 +90,7 @@ class MonthlyStories extends Component {
             href="https://medium.com/seasensors-africa"
           />
         </div>
-      </div>
+      </Section>
     );
   }
 }

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { withStyles } from '@material-ui/core';
+
+const styles = theme => ({
+  root: {
+    width: '100%'
+  },
+  content: {
+    margin: '5.125rem 1.875rem 4.9375rem',
+    [theme.breakpoints.up('md')]: {
+      // .75 of lg width
+      width: '87.5%',
+      margin: '7.875rem 4.171875rem 12.46875rem'
+    },
+    [theme.breakpoints.up('lg')]: {
+      margin: '7.875rem 5.5625rem 12.46875rem'
+    }
+  }
+});
+
+function Section({ classes, children }) {
+  return (
+    <div className={classes.root}>
+      <div className={classes.content}>{children}</div>
+    </div>
+  );
+}
+
+Section.propTypes = {
+  classes: PropTypes.shape().isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ])
+};
+
+Section.defaultProps = {
+  children: null
+};
+
+export default withStyles(styles)(Section);

--- a/src/components/VideoAudioStories.js
+++ b/src/components/VideoAudioStories.js
@@ -7,15 +7,12 @@ import { withStyles, Grid, Hidden, Typography } from '@material-ui/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faYoutube } from '@fortawesome/free-brands-svg-icons';
 
+import Section from './Section';
 import SectionTitle from './SectionTitle';
 
 const styles = theme => ({
   root: {
-    backgroundColor: '#F0F0F0',
-    padding: '5.125rem 1.875rem 4.9375rem',
-    [theme.breakpoints.up('md')]: {
-      padding: '7.875rem 5.5625rem 12.46875rem'
-    }
+    backgroundColor: '#F0F0F0'
   },
   channel: {
     display: 'flex',
@@ -30,7 +27,10 @@ const styles = theme => ({
     lineHeight: 4,
     letterSpacing: '0.8px',
     color: ' #023256',
-    marginRight: '1.8125rem'
+    marginRight: '1.359375rem', // .75 of lg
+    [theme.breakpoints.up('lg')]: {
+      marginRight: '1.8125rem'
+    }
   },
   channelName: {
     textDecoration: 'underline'
@@ -66,11 +66,17 @@ const styles = theme => ({
   },
   iframeContainerLeft: {
     [theme.breakpoints.up('md')]: {
+      marginRight: '1.0546875rem' // .75 of lg
+    },
+    [theme.breakpoints.up('lg')]: {
       marginRight: '1.40625rem'
     }
   },
   iframeContainerRight: {
     [theme.breakpoints.up('md')]: {
+      marginLeft: '1.0546875rem' // .75 of lg
+    },
+    [theme.breakpoints.up('lg')]: {
       marginLeft: '1.40625rem'
     }
   },
@@ -88,7 +94,7 @@ function VideoAudioStories(props) {
   const { classes, origin } = props;
 
   return (
-    <div className={classes.root}>
+    <Section classes={{ root: classes.root }}>
       <Grid container justify="space-between" className={classes.title}>
         <Grid item>
           <SectionTitle subtitle="Video & Audio Stories">
@@ -180,7 +186,7 @@ function VideoAudioStories(props) {
           </div>
         </Grid>
       </Grid>
-    </div>
+    </Section>
   );
 }
 

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -13,7 +13,7 @@ function News() {
     <Page>
       <NewsHeader />
       <MonthlyStories />
-      <VideoAudio />
+      <VideoAudio origin="https://seasensors.africa" />
       <OurPartners />
       <GetInvolved />
       <Footer />


### PR DESCRIPTION
##### What does this PR do?

Improves **News** page components (`Monthly Stories` and `Video & Audio Stories`) on `md` screen sizes.

##### Description of Task to be completed?

 - [x] Separate `lg` from `md` styles, and
 - [x] Introduce `md` sizes using `%`

##### Screenshots?

###### Medium screens

![m](https://user-images.githubusercontent.com/1779590/59501969-55199a00-8ea5-11e9-9ff1-21333878bf1f.jpg)

###### Extra large screens

![x](https://user-images.githubusercontent.com/1779590/59502011-737f9580-8ea5-11e9-9b9a-9df9a2c1ddc7.jpg)
